### PR TITLE
Allow reporting on public repositories

### DIFF
--- a/src/commands/dependency-debt/report.ts
+++ b/src/commands/dependency-debt/report.ts
@@ -24,7 +24,7 @@ export default class ReportDebt extends Command {
     auth: Flags.string({
       char: 'a',
       description: 'Authentication provider to use for Xeel API',
-      options: ['github', 'xeel'],
+      options: ['github', 'xeel', 'none'],
       default: 'xeel',
     }),
   };

--- a/src/reporter/xeel/auth-providers/index.ts
+++ b/src/reporter/xeel/auth-providers/index.ts
@@ -1,3 +1,9 @@
 export interface AuthProvider {
   getHeaders(): Promise<Headers>;
 }
+
+export class NoOpAuthProvider implements AuthProvider {
+  async getHeaders() {
+    return new Headers();
+  }
+}

--- a/src/reporter/xeel/index.ts
+++ b/src/reporter/xeel/index.ts
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 import type { EcosystemSupport } from '../../ecosystems/index.js';
 import { Reporter } from '../index.js';
 import GitHubAuthProvider from './auth-providers/github.js';
+import { NoOpAuthProvider } from './auth-providers/index.js';
 import XeelAuthProvider from './auth-providers/xeel.js';
 import { DebtAPI } from './graphql/apis/debt.js';
 import { ProjectAPI } from './graphql/apis/project.js';
@@ -47,6 +48,14 @@ export default class XeelReporter extends Reporter {
 
   private getAuthProvider(flags: unknown) {
     const selectedProvider = (flags as { auth: string }).auth;
+    if (selectedProvider === 'none') {
+      const repositoryId = (flags as { repository: string }).repository;
+      // Check if the repository ID provided is a GitHub repository URL
+      // If so, this is a public repository and we can skip authentication
+      if (repositoryId.includes('github.com/')) {
+        return new NoOpAuthProvider();
+      }
+    }
     switch (selectedProvider) {
       case 'github':
         return new GitHubAuthProvider(


### PR DESCRIPTION
In order to allow reporting on public repositories, enable the CLI to opt into a 'no-op' authenticator for the Xeel reporter.
This requires a GitHub URL be used as the repository identifier.