### PR TITLE
Harden reporting to errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xeel-dev/cli",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Xeel Command Line Interface",
   "license": "MIT",
   "bugs": "https://github.com/xeel-dev/xeel-cli/issues",


### PR DESCRIPTION
If a sub-project fails reporting, we still want to be able to send the data we _can_ collect, rather than failing fully. 