### PR TITLE
feat: changes dependency-debt to version-debt

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
       - run: pnpm build
       - run: ./bin/run.js plugins install @xeel-dev/cli-npm-plugin
       - run: ./bin/run.js plugins install @xeel-dev/cli-docker-plugin
-      - run: ./bin/run.js dependency-debt report --auth github --organization "x::org:64jlQszyh97h4u4d0IGc7J" --repository "$GITHUB_REPOSITORY_ID"
+      - run: ./bin/run.js version-debt report --auth github --organization "x::org:64jlQszyh97h4u4d0IGc7J" --repository "$GITHUB_REPOSITORY_ID"
         env:
           XEEL_API: 'https://api.xeel-dev.com' # Use the development API
           XEEL_APP: 'https://app.xeel-dev.com' # Use the development APP

--- a/.github/workflows/xeel.yml
+++ b/.github/workflows/xeel.yml
@@ -7,7 +7,7 @@ permissions:
   id-token: write
   contents: read
 jobs:
-  dependency-debt:
+  version-debt:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
@@ -23,7 +23,7 @@ jobs:
       - run: pnpm build
       - run: ./bin/run.js plugins install @xeel-dev/cli-npm-plugin
       - run: ./bin/run.js plugins install @xeel-dev/cli-docker-plugin
-      - run: ./bin/run.js dependency-debt report --auth github --organization "x::org:64jlQszyh97h4u4d0IGc7J" --repository "$GITHUB_REPOSITORY_ID"
+      - run: ./bin/run.js version-debt report --auth github --organization "x::org:64jlQszyh97h4u4d0IGc7J" --repository "$GITHUB_REPOSITORY_ID"
         env:
           XEEL_API: 'https://api.xeel-dev.com' # Use the development API
           XEEL_APP: 'https://app.xeel-dev.com' # Use the development APP

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 The Xeel CLI enables interfacing with Xeel's backend.
 
-Only dependency debt is currently supported.
+Only version debt is currently supported.
 
 ## Getting started
 

--- a/src/commands/version-debt/report.ts
+++ b/src/commands/version-debt/report.ts
@@ -63,7 +63,7 @@ export default class ReportDebt extends Command {
       }
     }
     if (!summary.success) {
-      throw new Error('Dependency debt report failed');
+      throw new Error('Version debt report failed');
     }
   }
 

--- a/src/reporter/xeel/index.ts
+++ b/src/reporter/xeel/index.ts
@@ -180,7 +180,7 @@ export default class XeelReporter extends Reporter {
           await debtApi.upsertDebt(subProjectId, subProjectDependencies);
         } catch (error) {
           summary.errors.push({
-            message: 'Failed to report dependency debt',
+            message: 'Failed to report version debt',
             details: JSON.stringify(error),
           });
           this.logError(subProject, error);
@@ -226,7 +226,7 @@ export default class XeelReporter extends Reporter {
               await debtApi.upsertDebt(subProjectId, subProjectDependencies);
             } catch (error) {
               summary.errors.push({
-                message: 'Failed to report dependency debt',
+                message: 'Failed to report version debt',
                 details: JSON.stringify(error),
               });
               this.logError(subProject, error);
@@ -234,7 +234,7 @@ export default class XeelReporter extends Reporter {
           }
         } catch (error) {
           summary.errors.push({
-            message: 'Failed to report dependency debt',
+            message: 'Failed to report version debt',
             details: JSON.stringify(error),
           });
           this.logError(project, error);
@@ -242,7 +242,7 @@ export default class XeelReporter extends Reporter {
       }
     } catch (error) {
       summary.errors.push({
-        message: 'Failed to report dependency debt',
+        message: 'Failed to report version debt',
         details: JSON.stringify(error),
       });
       this.logError(rootProject, error);
@@ -252,7 +252,7 @@ export default class XeelReporter extends Reporter {
 
   private logError(subProject: Project<string>, error: unknown) {
     if (this.isVerbose) {
-      console.error('Failed to report dependency debt', {
+      console.error('Failed to report version debt', {
         project: subProject.name,
         ecosystem: subProject.ecosystem,
         error,


### PR DESCRIPTION
Updates the name of the command to match the terminology used in Xeel

BREAKING CHANGE: Removes the `dependency-debt` command, replaces it with `version-debt`