### PR TITLE
feat(version-debt): add `totalDependencies` to version debt reporting

### DIFF
--- a/src/ecosystems/index.ts
+++ b/src/ecosystems/index.ts
@@ -81,4 +81,10 @@ export interface EcosystemSupport<T extends string> {
    * List all outdated dependencies for a project.
    */
   listOutdatedDependencies(project: Project<T>): Promise<Dependency<T>[]>;
+  /**
+   * Get the count of dependencies for a project.
+   *
+   * @since 1.1.0
+   */
+  countDependencies?(project: Project<T>): Promise<number>;
 }

--- a/src/reporter/xeel/graphql/apis/debt.ts
+++ b/src/reporter/xeel/graphql/apis/debt.ts
@@ -3,17 +3,29 @@ import { Dependency } from '../../../../ecosystems/index.js';
 import { GraphQLAPI } from './index.js';
 
 export class DebtAPI extends GraphQLAPI {
-  async upsertDebt(id: string, dependencies: Dependency<string>[]) {
+  async upsertDebt(
+    id: string,
+    dependencies: Dependency<string>[],
+    totalDependencies?: number,
+  ) {
     const document = gql`
-      mutation UpsertDebt($id: ID!, $dependencies: [InputDependency]!) {
-        upsertDependencyDebt(projectId: $id, dependencies: $dependencies) {
+      mutation UpsertDebt(
+        $id: ID!
+        $dependencies: [InputDependency]!
+        $totalDependencies: Int
+      ) {
+        upsertDependencyDebt(
+          projectId: $id
+          dependencies: $dependencies
+          totalDependencies: $totalDependencies
+        ) {
           debtScore
         }
       }
     `;
     const response = await this.client.request<{
       upsertDependencyDebt: { debtScore: number };
-    }>(document, { id, dependencies });
+    }>(document, { id, dependencies, totalDependencies });
     const { debtScore } = response.upsertDependencyDebt;
     return debtScore;
   }


### PR DESCRIPTION
This allows ecosystem support implementations to provide the reporter with a count of the total dependencies for a project, enabling Xeel to show average version debt per dependency.